### PR TITLE
feat: multi architecture build support for both amd64 and arm64

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,9 @@
     "migrate": "GOWORK=off atlas migrate apply --env gorm",
     "prebuild": "./scripts/optimize.sh",
     "preci": "./scripts/preci.sh",
-    "build": "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags=\"-w -s -X 'main.Version=v$VERSION'\" -o ./bin/main ./cmd/api/main.go",
-    "test": "go test ./...;"
+    "build:amd64": "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags=\"-w -s -X 'main.Version=v$VERSION'\" -o ./bin/main_amd64 ./cmd/api/main.go",
+    "build:arm64": "CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags=\"-w -s -X 'main.Version=v$VERSION'\" -o ./bin/main_arm64 ./cmd/api/main.go",
+    "build": "npm run build:amd64 && npm run build:arm64",
+    "test": "go test ./..."
   }
 }


### PR DESCRIPTION
# Add support for multi-architecture builds (amd64 & arm64)

## Why:
- To enable project to be deploy on `AWS Graviton` Instance

## Changes:

- Added separate build scripts: `build:amd64` and `build:arm64`

- Updated main `build` script to generate both architectures

- Output binaries: `./bin/main_amd64` and `./bin/main_arm64`

