### PR TITLE
Fix/Added ref for textbox

### DIFF
--- a/apps/web/app/_components/textbox.tsx
+++ b/apps/web/app/_components/textbox.tsx
@@ -1,34 +1,28 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, forwardRef } from "react";
 
-interface TextBoxProps {
+interface TextBoxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   name?: string;
   placeholder?: string;
   width?: string;
   errorMessage?: string;
-  value?: string;
-  onChange?: (value: string) => void;
-  size?: 'default' | 'small';
-  variant?: 'default' | 'light'; // Add color variant
+  textSize?: 'default' | 'small';
+  variant?: 'default' | 'light';
 }
 
-const TextBox: React.FC<TextBoxProps> = ({
+const TextBox = forwardRef<HTMLInputElement, TextBoxProps>(({
   name,
   placeholder = "",
   width = "100%",
   errorMessage = "",
-  value = "",
-  onChange = () => {},
-  size = 'default',
-  variant = 'default', // Default color variant
-}) => {
+  value,
+  onChange,
+  textSize = 'default',
+  variant = 'default',
+  ...props
+}, ref) => {
   const [isFocused, setIsFocused] = useState(false);
-  const [inputValue, setInputValue] = useState(value);
-
-  useEffect(() => {
-    setInputValue(value);
-  }, [value]);
 
   // Define styles
   const sizeStyles = {
@@ -41,7 +35,7 @@ const TextBox: React.FC<TextBoxProps> = ({
     light: 'bg-transparent border-lightgrey/50'
   };
   
-  const baseStyles = `rounded-lg border-2 outline-none text-caption w-full placeholder:italic ${sizeStyles[size]}`;
+  const baseStyles = `rounded-lg border-2 outline-none text-caption w-full placeholder:italic ${sizeStyles[textSize]}`;
   const defaultStyles = variantStyles[variant];
   const focusStyles = `border-orange ${variant === 'light' ? 'bg-transparent' : ''}`;
   const errorStyles = `border-red`;
@@ -52,29 +46,31 @@ const TextBox: React.FC<TextBoxProps> = ({
       ? focusStyles
       : defaultStyles;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    setInputValue(newValue);
-    onChange(newValue);
-  };
+  // Check if it's being used as controlled or uncontrolled
+  const isControlled = value !== undefined;
 
   return (
     <div style={{ width }}>
       <input
+        ref={ref}
         type="text"
         name={name}
         placeholder={placeholder}
-        value={inputValue}
+        // Only pass value if this is being used as a controlled component
+        {...(isControlled ? { value } : {})}
         className={`${baseStyles} ${currentStyles}`}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
-        onChange={handleChange}
+        onChange={onChange}
+        {...props}
       />
       {errorMessage && (
         <p className="text-red text-caption mt-1">{errorMessage}</p>
       )}
     </div>
   );
-};
+});
+
+TextBox.displayName = "TextBox";
 
 export default TextBox;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,18 +1,31 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import Header from "./_components/header";
 import Footer from "./_components/footer";
 import TextBox from "./_components/textbox";
 import Dropdown from "./_components/dropdown";
 import ProfilePhoto from "./_components/profilephoto";
 import IconWithLabel from "./_components/iconwithlabel";
-// add
 import { MapPin } from "lucide-react";
 
 export default function Page() {
   const [selected, setSelected] = useState<string[]>([]);
-  const [inputValue, setInputValue] = useState("Use case: prefilled names");
+  const [inputValue, setInputValue] = useState("");
+  const [hasError, setHasError] = useState(false);
+  const input1Ref = useRef<HTMLInputElement>(null);
+  const input2Ref = useRef<HTMLInputElement>(null);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    console.log(e.target.value);
+  };
+
+  // Validate on blur
+  const validateInput = () => {
+    const isEmpty = input1Ref.current?.value === "";
+    setHasError(isEmpty || false);
+  };
 
   return (
     <main className="font-poppins w-full">
@@ -20,11 +33,21 @@ export default function Page() {
       <Footer />
       This is a page
       <TextBox
-        name="test"
+        ref={input1Ref}
+        name="defaultExample"
+        placeholder="Enter text here"
+        // No value prop for uncontrolled
+        defaultValue="" // Use defaultValue instead
+        onBlur={validateInput}
+        errorMessage={hasError ? "Input can't be empty" : ""}
+      />
+      <TextBox
+        ref={input2Ref}
+        name="defaultExample"
         placeholder="Enter text here"
         value={inputValue}
+        onChange={handleInputChange}
         errorMessage={inputValue === "" ? "Input can't be empty" : ""}
-        onChange={(value) => setInputValue(value)} // Update state on change
       />
       <Dropdown
         selected={selected}
@@ -32,8 +55,15 @@ export default function Page() {
         defaultText="Select something bro"
         options={["a", "b", "c", "d", "e"]}
       />
-      <p className="mt-4">Current value: {inputValue}</p>
-      <button onClick={() => console.log(selected)}>log selected</button>
+      <p className="mt-4">Current value 1: {input1Ref.current?.value}</p>
+      <p className="mt-4">Current value 2: {input2Ref.current?.value}</p>
+
+      <button onClick={() => {
+        console.log("Input value:", input1Ref.current?.value);
+        console.log("Selected:", selected);
+      }}>
+        Log values
+      </button>
       <ProfilePhoto allowEdit={true} />
       <IconWithLabel icon={MapPin} label="Chulalongkorn University" size={24} />
     </main>


### PR DESCRIPTION
###  `TextBox`

* Refactored `TextBox` component to use `forwardRef` for better ref handling and extended `TextBoxProps` to include `React.InputHTMLAttributes<HTMLInputElement>`.
* Removed internal state and `useEffect` for managing input value, allowing the component to be used as either controlled or uncontrolled.
* Added a check to determine if the component is controlled based on the presence of the `value` prop.

### `Page`:
* Sample `TextBox` usage, both controlled and uncontrolled.
* Added `useRef` hooks for `TextBox` inputs to manage references and handle validation on blur.
* Updated the `Page` component to handle input changes and validate the input fields, displaying error messages when necessary.